### PR TITLE
Use configuration from SigmaHQ/pysigma-backend-datadog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,16 +9,18 @@ on:
 jobs:
   build-and-publish:
     runs-on: ubuntu-20.04
+    environment: release
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - name: Install Poetry
+        run: pipx install poetry
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
-      - name: Install Poetry
-        uses: abatilo/actions-poetry@v2.0.0
-        with:
-          poetry-version: 1.2
       - name: Verify versioning
         run: |
           [ "$(poetry version -s)" == "${GITHUB_REF#refs/tags/v}" ]
@@ -28,14 +30,11 @@ jobs:
         run: poetry run pytest
       - name: Build packages
         run: poetry build
-      - name: Configure Poetry
-        run: |
-          poetry config repositories.testpypi https://test.pypi.org/legacy/
-          poetry config pypi-token.testpypi ${{ secrets.TEST_PYPI_API_TOKEN }}
-          poetry config pypi-token.pypi "${{ secrets.PYPI_API_TOKEN }}"
       - name: Publish to test PyPI
         if: ${{ github.event_name == 'push' }}
-        run: poetry publish -r testpypi
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
       - name: Publish to PyPI
         if: ${{ github.event_name == 'release' }}
-        run: poetry publish
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,19 +11,16 @@ jobs:
     strategy:
       matrix:
         os: [ 'ubuntu-20.04' ]
-        python-version: [ '3.8', '3.9', '3.10' ]
-        poetry-version: [ '1.4.2' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - name: Install Poetry
+        run: pipx install poetry
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install Poetry
-        uses: abatilo/actions-poetry@v2.0.0
-        with:
-          poetry-version: ${{ matrix.poetry-version }}
       - name: Install dependencies
         run: poetry install
       - name: Run tests
@@ -32,11 +29,11 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         run: poetry run python print-coverage.py >> $GITHUB_ENV
       - name: Create coverage badge
-        if: ${{ github.repository == 'Datadog/pySigma-backend-datadog' && github.event_name == 'push' && runner.os == 'MacOS' }}
-        uses: schneegans/dynamic-badges-action@v1.1.0
+        if: ${{ github.repository == 'SigmaHQ/pySigma-backend-datadog' && github.event_name == 'push' && runner.os == 'Linux' }}
+        uses: schneegans/dynamic-badges-action@v1.7.0
         with:
           auth: ${{ secrets.GIST_SECRET }}
-          gistID: GitHub Gist identifier containing coverage badge JSON expected by shields.io.
+          gistID: b4bb678c2533ee5dd3f4d06fa43198dc
           filename: pySigma-backend-datadog.json
           label: Coverage
           message: ${{ env.COVERAGE }}


### PR DESCRIPTION
Release workflow is currently borken due to an old version of poetry in the Release workflow.

This update takes the version which are defined here: https://github.com/SigmaHQ/pySigma-backend-datadog/tree/main/.github/workflows