### PR TITLE
Fix escape and field mapping

### DIFF
--- a/sigma/backends/datadog/datadog.py
+++ b/sigma/backends/datadog/datadog.py
@@ -74,7 +74,7 @@ class DatadogBackend(TextQueryBackend):
     wildcard_multi: ClassVar[str] = "*"  # Character used as multi-character wildcard
     wildcard_single: ClassVar[str] = "*"  # Character used as single-character wildcard
     add_escaped: ClassVar[str] = (
-        ' + - = && || ! ( ) { } [ ] < > ^ “ ” ~ * ? : " # '  # Characters quoted in addition to wildcards and string quote
+        ' + - = && || ! ( ) { } [ ] < > ^ “ ” ~ * ? " # '  # Characters quoted in addition to wildcards and string quote
     )
     bool_values: ClassVar[Dict[bool, str]] = {
         True: "true",

--- a/sigma/pipelines/datadog/datadog.py
+++ b/sigma/pipelines/datadog/datadog.py
@@ -32,10 +32,9 @@ class DatadogFieldMappingTransformation(FieldMappingTransformation):
         queries.
         """
         mapping = self.mapping.get(field)
-        if not mapping:
+        if not mapping and field:
             return f"@{field}"
-        else:
-            return mapping
+        return mapping
 
 
 def datadog_pipeline() -> ProcessingPipeline:


### PR DESCRIPTION
## Changes

- Remove `:` from `add_escaped`
- Update the field mapping in pipeline 

## Test

`sigma convert -t datadog sigma/rules/application/ruby/appframework_ruby_on_rails_exceptions.yml`

Returned 
```
@None:ActionController\:\:InvalidAuthenticityToken OR @None:ActionController\:\:InvalidCrossOriginRequest OR @None:ActionController\:\:MethodNotAllowed OR @None:ActionController\:\:BadRequest OR @None:ActionController\:\:ParameterMissing
```

Now it returns
```
"ActionController::InvalidAuthenticityToken" OR "ActionController::InvalidCrossOriginRequest" OR "ActionController::MethodNotAllowed" OR "ActionController::BadRequest" OR "ActionController::ParameterMissing"
```