### PR TITLE
Mark this repository as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # pySigma Datadog Backend
 
+> ⚠️ **This repository is deprecated.**
+> The official repository is now [SigmaHQ/pySigma-backend-datadog](https://github.com/SigmaHQ/pySigma-backend-datadog).
+> Please submit all issues, pull requests, and contributions there. Thank you!
+
 ![Tests](https://github.com/SigmaHQ/pySigma-backend-datadog/actions/workflows/test.yml/badge.svg)
 ![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/thomaspatzke/b4bb678c2533ee5dd3f4d06fa43198dc/raw/pySigma-backend-datadog.json)
 ![Status](https://img.shields.io/badge/Status-pre--release-orange)


### PR DESCRIPTION
- Mark this repository as deprecated and replaced by https://github.com/SigmaHQ/pySigma-backend-datadog.

- This is to simplify and avoid any issues with release to Pypi and keep things clear for the users of the backend, all new contributions will take place in https://github.com/SigmaHQ/pySigma-backend-datadog

- https://github.com/SigmaHQ/pySigma-backend-datadog is fully in sync with the latest version of this repo, before this PR